### PR TITLE
stable version of ck\file_marc_reference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3",
-        "ck/File_MARC_Reference": "dev-master",
+        "ck/file_marc_reference": "~1.0",
         "pear/file_marc": "*"
     },
     "require-dev": {


### PR DESCRIPTION
I released a stable version of ck\file_marc_reference. This should avoid troubles with minimum-stability https://github.com/scriptotek/php-marc/issues/1 
