### PR TITLE
Add getters and document classes thoroughly.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     "require": {
         "php": ">=5.6",
         "ext-xml": "*",
+        "ext-json": "*",
         "ck/file_marc_reference": "^1.2",
-        "pear/file_marc": "^1.1",
-        "ext-json": "*"
+        "pear/file_marc": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7 | ^6.0 | ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "php": ">=5.6",
         "ext-xml": "*",
         "ck/file_marc_reference": "^1.2",
-        "pear/file_marc": "^1.1"
+        "pear/file_marc": "^1.1",
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7 | ^6.0 | ^7.0",

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -2,10 +2,12 @@
 
 namespace Scriptotek\Marc\Fields;
 
+use File_MARC_Field;
+use JsonSerializable;
 use Scriptotek\Marc\MagicAccess;
 use Scriptotek\Marc\Record;
 
-class Field implements \JsonSerializable
+class Field implements JsonSerializable
 {
     use SerializableField, MagicAccess;
 
@@ -19,7 +21,7 @@ class Field implements \JsonSerializable
 
     protected $field;
 
-    public function __construct(\File_MARC_Field $field)
+    public function __construct(File_MARC_Field $field)
     {
         $this->field = $field;
     }

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -24,6 +24,11 @@ class Field implements \JsonSerializable
         $this->field = $field;
     }
 
+    /**
+     * Get the wrapped field.
+     *
+     * @return \File_MARC_Field
+     */
     public function getField()
     {
         return $this->field;

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -29,23 +29,6 @@ class Field implements \JsonSerializable
         return $this->field;
     }
 
-    public function jsonSerialize()
-    {
-        if (count($this->properties)) {
-            $o = [];
-            foreach ($this->properties as $prop) {
-                $value = $this->$prop;
-                if (is_object($value)) {
-                    $o[$prop] = $value->jsonSerialize();
-                } elseif ($value) {
-                    $o[$prop] = $value;
-                }
-            }
-            return $o;
-        }
-        return (string) $this;
-    }
-
     public function __call($name, $args)
     {
         return call_user_func_array([$this->field, $name], $args);

--- a/src/MagicAccess.php
+++ b/src/MagicAccess.php
@@ -3,6 +3,11 @@
 
 namespace Scriptotek\Marc;
 
+/**
+ * A trait that allows all getters to be accessed as properties.
+ *
+ * @package Scriptotek\Marc
+ */
 trait MagicAccess
 {
     public function __get($key)

--- a/src/Record.php
+++ b/src/Record.php
@@ -17,7 +17,25 @@ use Scriptotek\Marc\Fields\Field;
  * have to copy or rewrite the functionality in the `next()` and `_decode()`
  * methods of File_MARC and File_MARCXML, which are hard-wired to call
  * `new File_MARC_Record()`. The down-side of the wrapping approach is that we
- * break static code analysis and IDE code hinting.
+ * impede static code analysis and IDE code hinting.
+ *
+ * Methods on the wrapped record that are not implemented here may be accessed
+ * using magic method calls, or through `getRecord()`. Method tags are included
+ * below to aid IDE code hinting, but using the getter will give you better code
+ * hinting and documentation.
+ *
+ * @method string getLeader()
+ * @method string setLeader(string $leader)
+ * @method File_MARC_Field appendField(File_MARC_Field $new_field)
+ * @method File_MARC_Field prependField(File_MARC_Field $new_field)
+ * @method File_MARC_Field insertField(File_MARC_Field $new_field, File_MARC_Field $existing_field, bool $before = false)
+ * @method bool setLeaderLengths(int $record_length, int $base_address)
+ * @method int deleteFields(string $tag, bool $pcre = null)
+ * @method addWarning(string $warning)
+ * @method string toRaw()
+ * @method string toJSON()
+ * @method string toJSONHash
+ * @method string toXML(string $encoding = "UTF-8", bool $indent = true, bool $single = true)
  *
  * @property string id
  * @property string type

--- a/src/Record.php
+++ b/src/Record.php
@@ -42,6 +42,16 @@ class Record implements \JsonSerializable
         $this->record = $record;
     }
 
+    /**
+     * Get the wrapped record.
+     *
+     * @return \File_MARC_Record
+     */
+    public function getRecord()
+    {
+        return $this->record;
+    }
+
     public function getField($spec = null, $pcre = null)
     {
         $q = $this->record->getField($spec, $pcre);

--- a/src/Record.php
+++ b/src/Record.php
@@ -70,12 +70,24 @@ class Record implements \JsonSerializable
         return $this->record;
     }
 
+    /**
+     * Find and wrap the specified MARC field.
+     *
+     * @param string $spec
+     *   The tag name.
+     * @param bool $pcre
+     *   If true, match as a regular expression.
+     *
+     * @return \Scriptotek\Marc\Fields\Field|null
+     *   A wrapped field, or NULL if not found.
+     */
     public function getField($spec = null, $pcre = null)
     {
         $q = $this->record->getField($spec, $pcre);
         if ($q) {
             return new Field($q);
         }
+        return null;
     }
 
     public function getFields($spec = null, $pcre = null)

--- a/src/Record.php
+++ b/src/Record.php
@@ -5,6 +5,7 @@ namespace Scriptotek\Marc;
 use File_MARC_Field;
 use File_MARC_Record;
 use File_MARC_Reference;
+use JsonSerializable;
 use Scriptotek\Marc\Exceptions\RecordNotFound;
 use Scriptotek\Marc\Exceptions\UnknownRecordType;
 use Scriptotek\Marc\Fields\ControlField;
@@ -40,7 +41,7 @@ use Scriptotek\Marc\Fields\Field;
  * @property string id
  * @property string type
  */
-class Record implements \JsonSerializable
+class Record implements JsonSerializable
 {
     use MagicAccess;
 

--- a/src/Record.php
+++ b/src/Record.php
@@ -45,6 +45,11 @@ class Record implements JsonSerializable
 {
     use MagicAccess;
 
+    /**
+     * The record that is being wrapped.
+     *
+     * @var \File_MARC_Record
+     */
     protected $record;
 
     /**
@@ -91,6 +96,17 @@ class Record implements JsonSerializable
         return null;
     }
 
+    /**
+     * Find and wrap the specified MARC fields.
+     *
+     * @param string $spec
+     *   The tag name.
+     * @param bool $pcre
+     *   If true, match as a regular expression.
+     *
+     * @return \Scriptotek\Marc\Fields\Field[]
+     *   An array of wrapped fields.
+     */
     public function getFields($spec = null, $pcre = null)
     {
         return array_values(array_map(function (File_MARC_Field $field) {
@@ -103,11 +119,14 @@ class Record implements JsonSerializable
      *************************************************************************/
 
     /**
-     * Returns the first record found in the file $filename, or null if no records found.
+     * Returns the first record found in the file $filename.
      *
-     * @param $filename
+     * @param string $filename
+     *   The name of the file containing the MARC records.
      * @return BibliographicRecord|HoldingsRecord|AuthorityRecord
+     *   A wrapped MARC record.
      * @throws RecordNotFound
+     *   When the file does not contain a MARC record.
      */
     public static function fromFile($filename)
     {
@@ -121,11 +140,14 @@ class Record implements JsonSerializable
     }
 
     /**
-     * Returns the first record found in the string $data, or null if no records found.
+     * Returns the first record found in the string $data.
      *
-     * @param $data
+     * @param string $data
+     *   The string in which to look for MARC records.
      * @return BibliographicRecord|HoldingsRecord|AuthorityRecord
+     *   A wrapped MARC record.
      * @throws RecordNotFound
+     *   When the string does not contain a MARC record.
      */
     public static function fromString($data)
     {
@@ -143,7 +165,8 @@ class Record implements JsonSerializable
      *************************************************************************/
 
     /**
-     * @param string $spec  The MARCspec string
+     * @param string $spec
+     *   The MARCspec string
      * @return QueryResult
      */
     public function query($spec)
@@ -156,11 +179,11 @@ class Record implements JsonSerializable
      *************************************************************************/
 
     /**
-     * Get the record type based on the value of LDR/6. Returns any of
-     * the Marc21::BIBLIOGRAPHIC, Marc21::AUTHORITY or Marc21::HOLDINGS
-     * constants.
+     * Get the record type based on the value of LDR/6.
      *
      * @return string
+     *   Any of the Marc21::BIBLIOGRAPHIC, Marc21::AUTHORITY or Marc21::HOLDINGS
+     *   constants.
      * @throws UnknownRecordType
      */
     public function getType()
@@ -187,6 +210,11 @@ class Record implements JsonSerializable
      * Support methods
      *************************************************************************/
 
+    /**
+     * Convert the MARC record into an array structure fit for `json_encode`.
+     *
+     * @return array
+     */
     public function jsonSerialize()
     {
         $o = [];
@@ -213,11 +241,26 @@ class Record implements JsonSerializable
         return $o;
     }
 
+    /**
+     * Delegate all unknown method calls to the wrapped record.
+     *
+     * @param string $name
+     *   The name of the method being called.
+     * @param array $args
+     *   The arguments being passed to the method.
+     *
+     * @return mixed
+     */
     public function __call($name, $args)
     {
         return call_user_func_array([$this->record, $name], $args);
     }
 
+    /**
+     * Get a string representation of this record.
+     *
+     * @return string
+     */
     public function __toString()
     {
         return strval($this->record);

--- a/tests/FieldsTest.php
+++ b/tests/FieldsTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests;
 
+use File_MARC_Field;
+use Scriptotek\Marc\Fields\Field;
 use Scriptotek\Marc\Record;
 
 class IsbnFieldTest extends TestCase
@@ -106,5 +108,18 @@ class IsbnFieldTest extends TestCase
 
         $field->delete();
         $this->assertNull($field->asLineMarc());
+    }
+
+    /**
+     * Test the getField method.
+     */
+    public function testGetField()
+    {
+        $wrapped_field = new File_MARC_Field('020', '$q h. $c Nkr 98.00');
+        $wrapper = new Field($wrapped_field);
+
+        // Make sure that the exact same wrapped field object is returned
+        // by the getter.
+        $this->assertSame($wrapped_field, $wrapper->getField());
     }
 }

--- a/tests/FieldsTest.php
+++ b/tests/FieldsTest.php
@@ -6,7 +6,7 @@ use File_MARC_Field;
 use Scriptotek\Marc\Fields\Field;
 use Scriptotek\Marc\Record;
 
-class IsbnFieldTest extends TestCase
+class FieldsTest extends TestCase
 {
     public function testIsbn()
     {

--- a/tests/RecordTest.php
+++ b/tests/RecordTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests;
 
+use File_MARC;
+use File_MARC_Record;
 use Scriptotek\Marc\AuthorityRecord;
 use Scriptotek\Marc\BibliographicRecord;
 use Scriptotek\Marc\Fields\Field;
@@ -100,5 +102,24 @@ class RecordTest extends TestCase
 
         $record = Record::fromString($source);
         $this->assertEquals(Marc21::ISBD_PUNCTUATION_OMITTED, $record->catalogingForm);
+    }
+
+    /**
+     * Test the getRecord method.
+     *
+     * @throws \File_MARC_Exception
+     */
+    public function testGetRecord()
+    {
+        $source = '<?xml version="1.0" encoding="UTF-8" ?>
+          <record>
+            <leader>99999cam a2299999 c 4500</leader>
+          </record>';
+        $wrapped_record = new File_MARC_Record(new File_MARC($source, File_MARC::SOURCE_STRING));
+        $wrapper = new Record($wrapped_record);
+
+        // Make sure that the exact same wrapped record object is returned
+        // by the getter.
+        $this->assertSame($wrapped_record, $wrapper->getRecord());
     }
 }


### PR DESCRIPTION
Here is my first PR for better code hinting as discussed in https://github.com/scriptotek/php-marc/issues/15 

I also took the liberty of (almost) fully documenting `Record.php`, `Field.php` and `MagicAccess.php`.

I also added a missing composer dependency on `ext-json`.