### PR TITLE
Init from simplexml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,35 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Added info to contributors (CONTRIBUTING.md).
+  ([62949a1](https://github.com/scriptotek/php-marc/commit/62949a1b2e1c309e3bf8bb58f9f8f138c0398d46))
+- Added initialization from SimpleXMLElement object through the new methods
+  `Collection:fromSimpleXMLElement($obj)` and `Record:fromSimpleXMLElement($obj)`.
+
+### Fixed
+
+- Improved documentation and support for IDE code analysis.
+  ([#15](https://github.com/scriptotek/php-marc/issues/15)
+  by [@rudolfbyker](https://github.com/rudolfbyker))
+
+## [2.0.2] - 2019-09-13
+
+### Added
+
 - Added new method `Field::asLineMarc()` to return a line mode Marc string
   representation of the field.
+  ([ba20a6d](https://github.com/scriptotek/php-marc/commit/ba20a6deadc9402bb65807cd63e33797d2893dea))
 
 ### Fixed
 
 - Fixed the `Subject::getParts()` method.
+  ([1fe8408](https://github.com/scriptotek/php-marc/commit/1fe8408e49c6c3afba9ec379b441c82f64ce0336))
+- Added additional subject subfield codes that were missing.
+  ([7908616](https://github.com/scriptotek/php-marc/commit/79086165dfce9b9d2f490d38e9f50f70fef5641f))
+- Added 852 $i and $j to `Location.callCode`.
+  ([cba1508](https://github.com/scriptotek/php-marc/commit/cba15083422bb2ac812b6b355341feab2cff308a))
+- Fixed the string representation of the `Location` class.
+  ([74652a3](https://github.com/scriptotek/php-marc/commit/74652a3bf4cc3e9fe3c916057a0a9bd47419f601))
 
 ## [2.0.1] - 2019-01-09
 
@@ -90,7 +113,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Record::fromString` now throws a `RecordNotFound` exception rather than an `ErrorException` exception if no record was found.
 - `Record::getType` now throws a `UnknownRecordType` exception rather than an `ErrorException`.
 
-[Unreleased]: https://github.com/scriptotek/php-marc/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/scriptotek/php-marc/compare/v2.0.2...HEAD
+[2.0.2]: https://github.com/scriptotek/php-marc/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/scriptotek/php-marc/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/scriptotek/php-marc/compare/v1.0.1...v2.0.0
 [1.0.1]: https://github.com/scriptotek/php-marc/compare/v1.0.0...v1.0.1

--- a/README.md
+++ b/README.md
@@ -8,15 +8,20 @@
 
 # scriptotek/marc
 
-A small PHP package providing a simple interface to work with MARC21 records
-on top of the excellent [File_MARC package](https://github.com/pear/File_MARC).
+This package provides a simple interface to work with MARC21 records using the excellent
+[File_MARC](https://github.com/pear/File_MARC) and [MARCspec](http://marcspec.github.io/)
+packages.
+It doesn't do any of the heavy lifting itself, but instead
 
-Works with both Binary MARC and MARCXML (namespaced or not), but not the various
-Line mode MARC formats. Records can be edited using the editing capabilities of
-File_MARC.
+- makes it a little bit easier to load data by automatically determining what you throw
+  at it (Binary MARC or MARCXML, namespaced XML or not, a collection of records in some
+  container or a single record).
+- adds a few extra convenience methods and a fluent interface to MARCspec.
 
-See [the changelog](CHANGELOG.md) for information about (breaking) changes.
-See [CONTRIBUTING.md](CONTRIBUTING.md) for information about contributing to the project.
+If you don't need any of this, you might want to use File_MARC directly instead.
+
+Want to contribute to this project?
+Please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Installation using Composer:
 
@@ -73,6 +78,13 @@ use Scriptotek\Marc\Record;
 
 $record = Record::fromFile($someFileName);
 ```
+
+## Editing records
+
+Records can be edited using the editing capabilities of File_MARC
+([API docs](https://pear.php.net/package/File_MARC/docs/latest/)).
+See [an example](https://github.com/scriptotek/php-marc/issues/13#issuecomment-522036879)
+to get started.
 
 ## Querying with MARCspec
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ composer require scriptotek/marc
 
 ## Reading records
 
-Use `Collection::fromFile` or `Collection::fromString` to read one or more
-MARC records from a file or string. The methods autodetect the data format
-(Binary XML or MARCXML) and whether the XML is namespaced or not.
+Use `Collection::fromFile`, `Collection::fromString` or `Collection::fromSimpleXMLElement`
+to read one or more MARC records from a file or string. The methods autodetect the data
+format (Binary XML or MARCXML) and whether the XML is namespaced or not.
 
 ```php
 use Scriptotek\Marc\Collection;
@@ -64,9 +64,9 @@ foreach ($records as $record) {
 }
 ```
 
-If you only have a single record, you can also use `Record::fromFile` or
-`Record::fromString`. These use the `Collection` methods under the hood,
-but returns a single `Record` object.
+If you only have a single record, you can also use `Record::fromFile`,
+`Record::fromString` or `Record::fromSimpleXMLElement`. These use the
+`Collection` methods under the hood, but returns a single `Record` object.
 
 ```php
 use Scriptotek\Marc\Record;

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-xml": "*",
         "ext-json": "*",
         "ck/file_marc_reference": "^1.2",
-        "pear/file_marc": "^1.1"
+        "pear/file_marc": "^1.4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7 | ^6.0 | ^7.0",

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -6,6 +6,8 @@ use File_MARC_Record;
 use Scriptotek\Marc\Exceptions\RecordNotFound;
 use Scriptotek\Marc\Exceptions\UnknownRecordType;
 use Scriptotek\Marc\Importers\Importer;
+use Scriptotek\Marc\Importers\XmlImporter;
+use SimpleXMLElement;
 
 class Collection implements \Iterator
 {
@@ -49,6 +51,19 @@ class Collection implements \Iterator
         $importer = new Importer();
 
         return $importer->fromString($data);
+    }
+
+    /**
+     * Load records from a SimpleXMLElement object.
+     *
+     * @param SimpleXMLElement $element
+     * @return Collection
+     */
+    public static function fromSimpleXMLElement(SimpleXMLElement $element)
+    {
+        $importer = new XmlImporter($element);
+
+        return $importer->getCollection();
     }
 
     /**

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -3,6 +3,7 @@
 namespace Scriptotek\Marc;
 
 use File_MARC_Record;
+use Scriptotek\Marc\Exceptions\RecordNotFound;
 use Scriptotek\Marc\Exceptions\UnknownRecordType;
 use Scriptotek\Marc\Importers\Importer;
 
@@ -97,6 +98,21 @@ class Collection implements \Iterator
     public function toArray()
     {
         return iterator_to_array($this);
+    }
+
+    /**
+     * Return the first record in the collection.
+     *
+     * @return BibliographicRecord|HoldingsRecord|AuthorityRecord
+     * @throws RecordNotFound if the collection is empty
+     */
+    public function first()
+    {
+        $this->rewind();
+        if (is_null($this->current())) {
+            throw new RecordNotFound();
+        }
+        return $this->current();
     }
 
     /**

--- a/src/Importers/Importer.php
+++ b/src/Importers/Importer.php
@@ -5,6 +5,7 @@ namespace Scriptotek\Marc\Importers;
 use File_MARC;
 use Scriptotek\Marc\Collection;
 use Scriptotek\Marc\Factory;
+use SimpleXMLElement;
 
 class Importer
 {

--- a/src/Record.php
+++ b/src/Record.php
@@ -130,13 +130,7 @@ class Record implements JsonSerializable
      */
     public static function fromFile($filename)
     {
-        $records = Collection::fromFile($filename)->toArray();
-
-        if (!count($records)) {
-            throw new RecordNotFound();
-        }
-
-        return $records[0];
+        return Collection::fromFile($filename)->first();
     }
 
     /**
@@ -151,13 +145,7 @@ class Record implements JsonSerializable
      */
     public static function fromString($data)
     {
-        $records = Collection::fromString($data)->toArray();
-
-        if (!count($records)) {
-            throw new RecordNotFound();
-        }
-
-        return $records[0];
+        return Collection::fromString($data)->first();
     }
 
     /*************************************************************************

--- a/src/Record.php
+++ b/src/Record.php
@@ -10,6 +10,7 @@ use Scriptotek\Marc\Exceptions\RecordNotFound;
 use Scriptotek\Marc\Exceptions\UnknownRecordType;
 use Scriptotek\Marc\Fields\ControlField;
 use Scriptotek\Marc\Fields\Field;
+use SimpleXMLElement;
 
 /**
  * The MARC record wrapper.
@@ -146,6 +147,21 @@ class Record implements JsonSerializable
     public static function fromString($data)
     {
         return Collection::fromString($data)->first();
+    }
+
+    /**
+     * Returns the first record found in the SimpleXMLElement object
+     *
+     * @param SimpleXMLElement $element
+     *   The SimpleXMLElement object in which to look for MARC records.
+     * @return BibliographicRecord|HoldingsRecord|AuthorityRecord
+     *   A wrapped MARC record.
+     * @throws RecordNotFound
+     *   When the object does not contain a MARC record.
+     */
+    public static function fromSimpleXMLElement(SimpleXMLElement $element)
+    {
+        return Collection::fromSimpleXMLElement($element)->first();
     }
 
     /*************************************************************************

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -2,32 +2,21 @@
 
 namespace Tests;
 
+use Scriptotek\Marc\BibliographicRecord;
 use Scriptotek\Marc\Collection;
 use Scriptotek\Marc\Exceptions\XmlException;
 
 class CollectionTest extends TestCase
 {
+    /**
+     * Test that an empty Collection is created if no MARC records were found in the input.
+     */
     public function testEmptyCollection()
     {
         $source = '<?xml version="1.0" encoding="UTF-8" ?><test></test>';
 
         $collection = Collection::fromString($source);
         $this->assertCount(0, $collection->toArray());
-    }
-
-    public function testBinaryMarc()
-    {
-        $records = $this->getTestCollection('sandburg.mrc')->toArray();
-
-        $this->assertCount(1, $records);
-        $this->assertEquals('Arithmetic', $records[0]->title);
-    }
-
-    public function testBibsysOaiPmhSample()
-    {
-        $collection = $this->getTestCollection('oaipmh-bibsys.xml');
-
-        $this->assertCount(89, $collection->toArray());
     }
 
     /**
@@ -40,38 +29,50 @@ class CollectionTest extends TestCase
         $this->getTestCollection('alma-bibs-api-invalid.xml');
     }
 
-    public function testLocSample()
+    /**
+     * Define a list of sample binary MARC files that we can test with,
+     * and the expected number of records in each.
+     *
+     * @return array
+     */
+    public function mrcFiles()
     {
-        $collection = $this->getTestCollection('sru-loc.xml');
-
-        $this->assertCount(10, $collection->toArray());
+        return [
+            ['sandburg.mrc', 1],        // Single binary MARC file
+        ];
     }
 
-    public function testBibsysSample()
+    /**
+     * Define a list of sample XML files from different sources that we can test with,
+     * and the expected number of records in each.
+     *
+     * @return array
+     */
+    public function xmlFiles()
     {
-        $collection = $this->getTestCollection('sru-bibsys.xml');
-
-        $this->assertCount(117, $collection->toArray());
+        return [
+            ['oaipmh-bibsys.xml', 89],  // Records encapsulated in OAI-PMH response
+            ['sru-loc.xml', 10],        // Records encapsulated in SRU response
+            ['sru-bibsys.xml', 117],    // (Another one)
+            ['sru-zdb.xml', 8],         // (Another one)
+            ['sru-kth.xml', 10],        // (Another one)
+            ['sru-alma.xml', 3],        // (Another one)
+        ];
     }
 
-    public function testZdbSample()
+    /**
+     * Test that the sample files can be loaded using Collection::fromFile
+     *
+     * @dataProvider mrcFiles
+     * @dataProvider xmlFiles
+     * @param string $filename
+     * @param int $expected
+     */
+    public function testCollectionFromFile($filename, $expected)
     {
-        $collection = $this->getTestCollection('sru-zdb.xml');
+        $records = $this->getTestCollection($filename)->toArray();
 
-        $this->assertCount(8, $collection->toArray());
-    }
-
-    public function testKthSample()
-    {
-        $collection = $this->getTestCollection('sru-kth.xml');
-
-        $this->assertCount(10, $collection->toArray());
-    }
-
-    public function testAlmaSample()
-    {
-        $collection = $this->getTestCollection('sru-alma.xml');
-
-        $this->assertCount(3, $collection->toArray());
+        $this->assertCount($expected, $records);
+        $this->assertInstanceOf(BibliographicRecord::class, $records[0]);
     }
 }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -75,4 +75,21 @@ class CollectionTest extends TestCase
         $this->assertCount($expected, $records);
         $this->assertInstanceOf(BibliographicRecord::class, $records[0]);
     }
+
+
+    /**
+     * Test that the sample files can be loaded using Collection::fromSimpleXMLElement.
+     *
+     * @dataProvider xmlFiles
+     * @param string $filename
+     * @param int $expected
+     */
+    public function testInitializeFromSimpleXmlElement($filename, $expected)
+    {
+        $el = simplexml_load_file($this->pathTo($filename));
+
+        $collection = Collection::fromSimpleXMLElement($el);
+
+        $this->assertCount($expected, $collection->toArray());
+    }
 }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Scriptotek\Marc\Collection;
+use Scriptotek\Marc\Exceptions\XmlException;
 
 class CollectionTest extends TestCase
 {
@@ -30,13 +31,12 @@ class CollectionTest extends TestCase
     }
 
     /**
-     * @expectedException Scriptotek\Marc\Exceptions\XmlException
+     * Test that it XmlException is thrown when the specified encoding (UTF-16)
+     * differs from the actual encoding (UTF-8).
      */
-    public function testAlmaBibsApiExample()
+    public function testExceptionOnInvalidEncoding()
     {
-        // Expect failure because of invalid encoding in XML declaration:
-        // Document labelled UTF-16 but has UTF-8 content
-
+        $this->expectException(XmlException::class);
         $this->getTestCollection('alma-bibs-api-invalid.xml');
     }
 

--- a/tests/RecordTest.php
+++ b/tests/RecordTest.php
@@ -6,6 +6,7 @@ use File_MARC;
 use File_MARC_Record;
 use Scriptotek\Marc\AuthorityRecord;
 use Scriptotek\Marc\BibliographicRecord;
+use Scriptotek\Marc\Exceptions\RecordNotFound;
 use Scriptotek\Marc\Fields\Field;
 use Scriptotek\Marc\Fields\Subject;
 use Scriptotek\Marc\HoldingsRecord;
@@ -121,5 +122,41 @@ class RecordTest extends TestCase
         // Make sure that the exact same wrapped record object is returned
         // by the getter.
         $this->assertSame($wrapped_record, $wrapper->getRecord());
+    }
+
+    /**
+     * Test that a Record wrapper object will not be initialized from
+     * an SimpleXMLElement object that doesn't contain a MARC record.
+     */
+    public function testInitializeFromInvalidSimpleXMLElement()
+    {
+        $source = simplexml_load_string(
+            '<?xml version="1.0" encoding="UTF-8" ?><book></book>'
+        );
+
+        $this->expectException(RecordNotFound::class);
+        $record = Record::fromSimpleXMLElement($source);
+    }
+
+    /**
+     * Test that a Record wrapper object can be initialized from
+     * a SimpleXMLElement object.
+     */
+    public function testInitializeFromSimpleXmlElement()
+    {
+        $source = simplexml_load_string('<?xml version="1.0" encoding="UTF-8" ?>
+          <record xmlns="http://www.loc.gov/MARC21/slim">
+            <leader>99999cam a2299999 u 4500</leader>
+            <controlfield tag="001">98218834x</controlfield>
+            <datafield tag="020" ind1=" " ind2=" ">
+              <subfield code="a">8200424421</subfield>
+              <subfield code="q">h.</subfield>
+              <subfield code="c">Nkr 98.00</subfield>
+            </datafield>
+          </record>');
+
+        $record = Record::fromSimpleXMLElement($source);
+        $this->assertInstanceOf(Record::class, $record);
+        $this->assertInstanceOf(BibliographicRecord::class, $record);
     }
 }


### PR DESCRIPTION
Want to have a look at this, @rudolfbyker? Per #12 

A small bump in the road: We can only pass a SimpleXMLElement directly to File_MARC if it doesn't contain namespaces.

For this reason I'm still doing a serialization of the SimpleXMLElement followed by a deserialization in [`XmlImporter::getCollection()`](https://github.com/scriptotek/php-marc/blob/ba0624be0336cec2bd85dd389b69e54c71cff981/src/Importers/XmlImporter.php#L104). Less efficient, but more convenient, since the SimpleXMLElement object from an OAI response will often contain namespaces.

If the SimpleXMLElement object doesn't contain namespaces, we could pass it directly to File_MARC without any further processing though, so I thought about adding something like this on [line 112 in XmlImporter.php](https://github.com/scriptotek/php-marc/blob/ba0624be0336cec2bd85dd389b69e54c71cff981/src/Importers/XmlImporter.php#L112):

```
        if (count($records) == 1 && $ns == '') {
            // If we have a single record without namespaces, we can pass it directly to File_MARC
            $parser = $this->factory->make('File_MARCXML', $records[0], File_MARCXML::SOURCE_SIMPLEXMLELEMENT);
            return new Collection($parser);
        }
```

Not sure if it's worth the extra code complexity though. What do you think?