### PR TITLE
Make getSubfieldValues public.

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -156,7 +156,7 @@ class Field implements JsonSerializable
      * @return string[]
      *   The values that were contained in the requested subfields.
      */
-    protected function getSubfieldValues($codes)
+    public function getSubfieldValues($codes)
     {
         if (!is_array($codes)) {
             $codes = [$codes];


### PR DESCRIPTION
It would be very useful for me to be able to access `getSubfieldValues` from outside the object.