### PR TITLE
Fix jsonSerialize for return type compability

### DIFF
--- a/src/Record.php
+++ b/src/Record.php
@@ -219,7 +219,7 @@ class Record implements JsonSerializable
      *
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array|string
     {
         $o = [];
         foreach ($this->properties as $prop) {


### PR DESCRIPTION
The Record-Class was missing the correct return type for `jsonSerialize` and I added this for compability with PHP 8.1.