### PR TITLE
Update to pear/file_marc@dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: PHP ${{ matrix.php }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: php-actions/composer@v6
       with:
         php_version: ${{ matrix.php }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
     runs-on: ubuntu-latest
     name: PHP ${{ matrix.php }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         php:
           - "8.0"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,5 @@ jobs:
       with:
         php_version: ${{ matrix.php }}
         path: src/
-    - uses: php-actions/phpunit@v3
-      with:
-        php_version: ${{ matrix.php }}
-        php_extensions: pcov
+    - run: composer test
     - run: bash <(curl -s https://codecov.io/bash)

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ext-json": "*",
         "ext-simplexml": "*",
         "ck/file_marc_reference": "^1.2",
-        "pear/file_marc": "^1.4.1"
+        "pear/file_marc": "@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0 | ^9.0",

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -35,7 +35,7 @@ class CollectionTest extends TestCase
      *
      * @return array
      */
-    public function mrcFiles()
+    public static function mrcFiles()
     {
         return [
             ['sandburg.mrc', 1],        // Single binary MARC file
@@ -48,7 +48,7 @@ class CollectionTest extends TestCase
      *
      * @return array
      */
-    public function xmlFiles()
+    public static function xmlFiles()
     {
         return [
             ['oaipmh-bibsys.xml', 89],  // Records encapsulated in OAI-PMH response
@@ -86,7 +86,7 @@ class CollectionTest extends TestCase
      */
     public function testInitializeFromSimpleXmlElement($filename, $expected)
     {
-        $el = simplexml_load_file($this->pathTo($filename));
+        $el = simplexml_load_file(self::pathTo($filename));
 
         $collection = Collection::fromSimpleXMLElement($el);
 

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -26,9 +26,9 @@ class ExamplesTest extends TestCase
         }
     }
 
-    public function exampleDataProvider()
+    public static function exampleDataProvider()
     {
-        foreach (glob($this->pathTo('examples/*.xml')) as $filename) {
+        foreach (glob(self::pathTo('examples/*.xml')) as $filename) {
             yield [$filename];
         }
     }

--- a/tests/RecordTest.php
+++ b/tests/RecordTest.php
@@ -71,13 +71,13 @@ class RecordTest extends TestCase
 
     public function testBinaryMarc()
     {
-        $record = Record::fromFile($this->pathTo('binary-marc.mrc'));
+        $record = Record::fromFile(self::pathTo('binary-marc.mrc'));
         $this->assertInstanceOf(Record::class, $record);
     }
 
     public function testThatFieldObjectsAreReturned()
     {
-        $record = Record::fromFile($this->pathTo('binary-marc.mrc'));
+        $record = Record::fromFile(self::pathTo('binary-marc.mrc'));
         $this->assertInstanceOf(Field::class, $record->getField('020'));
         $this->assertInstanceOf(Field::class, $record->getFields('020')[0]);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,14 +7,14 @@ use Scriptotek\Marc\Record;
 
 class TestCase extends \PHPUnit\Framework\TestCase
 {
-    protected function pathTo($filename)
+    protected static function pathTo($filename)
     {
         return __DIR__ . '/data/' . $filename;
     }
 
     protected function getTestCollection($filename)
     {
-        return Collection::fromFile($this->pathTo($filename));
+        return Collection::fromFile(self::pathTo($filename));
     }
 
     protected function getNthrecord($filename, $n)


### PR DESCRIPTION
File_MARC was updated for PHP 8.1 compability in https://github.com/pear/File_MARC/pull/19 , but there hasn't been a new release, so I'm switching to use `@dev`

Also fixed tests and added PHP 8.3 as test target.