### PR TITLE
Avoid Deprecated curly braces

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -223,7 +223,7 @@ class Field implements JsonSerializable, FieldInterface
             $ind2 = $blank;
         }
 
-        return "${tag} ${ind1}${ind2} " . implode(' ', $subfields);
+        return "{$tag} {$ind1}{$ind2} " . implode(' ', $subfields);
     }
 
     /**


### PR DESCRIPTION
For PHP 8.2 curly brace ${var} are deprecated.
