### PR TITLE
Silence deprecations / PHP 8.4 compatibility (non-breaking)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor
+.phpunit.result.cache

--- a/src/BibliographicRecord.php
+++ b/src/BibliographicRecord.php
@@ -18,8 +18,18 @@ class BibliographicRecord extends Record
      * @var string[] List of properties to be included when serializing the record using the `toArray()` method.
      */
     public array $properties = [
-        'id', 'isbns', 'title', 'publisher', 'pub_year', 'edition',  'creators',
-        'subjects', 'classifications', 'toc', 'summary', 'part_of'
+        'id',
+        'isbns',
+        'title',
+        'publisher',
+        'pub_year',
+        'edition',
+        'creators',
+        'subjects',
+        'classifications',
+        'toc',
+        'summary',
+        'part_of'
     ];
 
     /**
@@ -114,7 +124,7 @@ class BibliographicRecord extends Record
             } else {
                 // Basic
                 return $field->mapSubFields([
-                   'a' => 'text',
+                    'a' => 'text',
                 ]);
             }
         }
@@ -131,8 +141,8 @@ class BibliographicRecord extends Record
         $field = $this->getField('520');
         if ($field) {
             return $field->mapSubFields([
-               'a' => 'text',
-               'c' => 'assigning_source',
+                'a' => 'text',
+                'c' => 'assigning_source',
             ]);
         }
         return null;
@@ -146,7 +156,7 @@ class BibliographicRecord extends Record
      * @param string|string[]|null $tag
      * @return SubjectInterface[]
      */
-    public function getSubjects(string $vocabulary = null, array|string $tag = null): array
+    public function getSubjects(?string $vocabulary = null, array|string|null $tag = null): array
     {
         $tag = is_null($tag) ? [] : (is_array($tag) ? $tag : [$tag]);
 
@@ -165,7 +175,7 @@ class BibliographicRecord extends Record
      * @param string|null $scheme
      * @return Classification[]
      */
-    public function getClassifications(string $scheme = null): array
+    public function getClassifications(?string $scheme = null): array
     {
         return array_values(array_filter(Classification::get($this), function ($classifications) use ($scheme) {
             $a = is_null($scheme) || $scheme == $classifications->getScheme();
@@ -181,7 +191,7 @@ class BibliographicRecord extends Record
      * @param string|string[]|null $tag
      * @return Person[]
      */
-    public function getCreators(array|string $tag = null): array
+    public function getCreators(array|string|null $tag = null): array
     {
         $tag = is_null($tag) ? [] : (is_array($tag) ? $tag : [$tag]);
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -24,7 +24,7 @@ class Collection implements \Iterator
      *
      * @param File_MARCXML|File_MARC|null $parser
      */
-    public function __construct(File_MARCXML|File_MARC $parser = null)
+    public function __construct(File_MARCXML|File_MARC|null $parser = null)
     {
         $this->parser = $parser;
     }
@@ -206,7 +206,7 @@ class Collection implements \Iterator
      * Magic
      *********************************************************/
 
-    public function __call($name, $arguments)
+    public function __call(string $name, array $arguments): mixed
     {
         return call_user_func_array([$this->parser, $name], $arguments);
     }

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -115,7 +115,7 @@ class Field implements JsonSerializable, FieldInterface
      *
      * @return mixed
      */
-    public function __call(string $name, array $args)
+    public function __call(string $name, array $args): mixed
     {
         return call_user_func_array([$this->field, $name], $args);
     }
@@ -140,7 +140,7 @@ class Field implements JsonSerializable, FieldInterface
      *
      * @return string
      */
-    protected function clean(string $value = null, array $options = []): string
+    protected function clean(?string $value = null, array $options = []): string
     {
         if (is_null($value)) {
             return "";
@@ -223,7 +223,7 @@ class Field implements JsonSerializable, FieldInterface
             $ind2 = $blank;
         }
 
-        return "${tag} ${ind1}${ind2} " . implode(' ', $subfields);
+        return "{$tag} {$ind1}{$ind2} " . implode(' ', $subfields);
     }
 
     /**
@@ -235,7 +235,7 @@ class Field implements JsonSerializable, FieldInterface
      *   The fallback value to return if the subfield does not exist.
      * @return string|null
      */
-    public function sf(string $code, string $default = null): ?string
+    public function sf(string $code, ?string $default = null): ?string
     {
         // In PHP, ("a" == 0) will evaluate to TRUE, so it's actually very important that we ensure type here!
         $code = (string) $code;

--- a/src/Fields/SerializableField.php
+++ b/src/Fields/SerializableField.php
@@ -4,7 +4,7 @@ namespace Scriptotek\Marc\Fields;
 
 trait SerializableField
 {
-    public function jsonSerialize(): array|string
+    public function jsonSerialize(): mixed
     {
         if (count($this->properties)) {
             $o = [];

--- a/src/Fields/Subfield.php
+++ b/src/Fields/Subfield.php
@@ -28,7 +28,7 @@ abstract class Subfield implements \JsonSerializable
         $this->__destruct();
     }
 
-    public function jsonSerialize(): string|array
+    public function jsonSerialize(): mixed
     {
         return (string) $this;
     }
@@ -38,12 +38,12 @@ abstract class Subfield implements \JsonSerializable
         return $this->subfield->getData();
     }
 
-    public function __call($name, $args)
+    public function __call(string $name, array $args): mixed
     {
         return call_user_func_array([$this->subfield, $name], $args);
     }
 
-    public function __get($key)
+    public function __get(string $key): mixed
     {
         $method = 'get' . ucfirst($key);
         if (method_exists($this, $method)) {

--- a/src/Importers/Importer.php
+++ b/src/Importers/Importer.php
@@ -11,7 +11,7 @@ class Importer
 {
     private Factory $factory;
 
-    public function __construct(Factory $factory = null)
+    public function __construct(?Factory $factory = null)
     {
         $this->factory = $factory ?? new Factory();
     }

--- a/src/Importers/XmlImporter.php
+++ b/src/Importers/XmlImporter.php
@@ -11,10 +11,9 @@ use SimpleXMLElement;
 
 class XmlImporter
 {
-    protected $factory;
+    protected Factory $factory;
 
-    /* var SimpleXMLElement */
-    protected $source;
+    protected SimpleXMLElement $source;
 
     /**
      * XmlImporter constructor.
@@ -22,11 +21,11 @@ class XmlImporter
      * @param string|SimpleXMLElement $data  Filename, XML string or SimpleXMLElement object
      * @param string $ns  URI or prefix of the namespace
      * @param bool $isPrefix TRUE if $ns is a prefix, FALSE if it's a URI; defaults to FALSE
-     * @param string $factory  (optional) Object factory, probably no need to set this outside testing.
+     * @param Factory|null $factory  (optional) Object factory, probably no need to set this outside testing.
      */
-    public function __construct($data, $ns = '', $isPrefix = false, $factory = null)
+    public function __construct($data, string $ns = '', bool $isPrefix = false, ?Factory $factory = null)
     {
-        $this->factory = isset($factory) ? $factory : new Factory();
+        $this->factory = $factory ?? new Factory();
 
         if (is_a($data, SimpleXMLElement::class)) {
             $this->source = $data;
@@ -40,10 +39,11 @@ class XmlImporter
         // Store errors internally so that we can fetch them with libxml_get_errors() later
         libxml_use_internal_errors(true);
 
-        $this->source = simplexml_load_string($data, 'SimpleXMLElement', 0, $ns, $isPrefix);
-        if (false === $this->source) {
+        $source = simplexml_load_string($data, 'SimpleXMLElement', 0, $ns, $isPrefix);
+        if (false === $source) {
             throw new XmlException(libxml_get_errors());
         }
+        $this->source = $source;
     }
 
     public function getMarcNamespace($namespaces)
@@ -98,7 +98,7 @@ class XmlImporter
 
         $parser = $this->factory->make('File_MARCXML', $record, File_MARCXML::SOURCE_SIMPLEXMLELEMENT, $ns);
 
-        return (new Collection($parser))->$this->getFirstRecord();
+        return (new Collection($parser))->first();
     }
 
     public function getCollection(): Collection

--- a/src/MagicAccess.php
+++ b/src/MagicAccess.php
@@ -9,7 +9,7 @@ namespace Scriptotek\Marc;
  */
 trait MagicAccess
 {
-    public function __get($key)
+    public function __get(string $key): mixed
     {
         // Convert key from underscore_case to camelCase.
         $key_uc = preg_replace_callback(
@@ -24,5 +24,7 @@ trait MagicAccess
         if (method_exists($this, $method)) {
             return call_user_func([$this, $method]);
         }
+
+        return null;
     }
 }

--- a/src/QueryResult.php
+++ b/src/QueryResult.php
@@ -29,7 +29,7 @@ class QueryResult implements IteratorAggregate, ArrayAccess, Countable
         $this->data = $ref->data;
         $this->content = $ref->content;
 
-        for ($i=0; $i < count($this->data); $i++) {
+        for ($i = 0; $i < count($this->data); $i++) {
             if (is_a($this->data[$i], File_MARC_Field::class)) {
                 $this->data[$i] = new Field($this->data[$i]);
             }
@@ -77,7 +77,7 @@ class QueryResult implements IteratorAggregate, ArrayAccess, Countable
      * @param mixed $offset An offset to check for.
      * @return boolean true on success or false on failure.
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->data[$offset]);
     }
@@ -88,7 +88,7 @@ class QueryResult implements IteratorAggregate, ArrayAccess, Countable
      * @param mixed $offset The offset to retrieve.
      * @return Field|File_MARC_Subfield|null
      */
-    public function offsetGet($offset): Field|File_MARC_Subfield|null
+    public function offsetGet(mixed $offset): Field|File_MARC_Subfield|null
     {
         return $this->data[$offset];
     }
@@ -99,7 +99,7 @@ class QueryResult implements IteratorAggregate, ArrayAccess, Countable
      * @param mixed $offset The offset to assign the value to.
      * @param mixed $value The value to set.
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         $this->data[$offset] = $value;
     }
@@ -109,7 +109,7 @@ class QueryResult implements IteratorAggregate, ArrayAccess, Countable
      * @link http://php.net/manual/en/arrayaccess.offsetunset.php
      * @param mixed $offset The offset to unset.
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->data[$offset]);
     }

--- a/src/Record.php
+++ b/src/Record.php
@@ -219,7 +219,7 @@ class Record implements JsonSerializable
      *
      * @return array
      */
-    public function jsonSerialize(): array|string
+    public function jsonSerialize(): mixed
     {
         $o = [];
         foreach ($this->properties as $prop) {
@@ -255,7 +255,7 @@ class Record implements JsonSerializable
      *
      * @return mixed
      */
-    public function __call($name, $args)
+    public function __call(string $name, array $args): mixed
     {
         return call_user_func_array([$this->record, $name], $args);
     }
@@ -265,7 +265,7 @@ class Record implements JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return strval($this->record);
     }


### PR DESCRIPTION
Add type hinting and return types for PHP 8.4 compatibility. Update .gitignore to include .phpunit.result.cache.
Silences deprecation warnings if using PHP8.4 without breaking compatibility with earlier versions.